### PR TITLE
swipeout组件增加一个toggleButtonGroup方法 以及对应的example

### DIFF
--- a/examples/pages/swipeout/index.js
+++ b/examples/pages/swipeout/index.js
@@ -6,6 +6,7 @@ Page({
         //小程序没有refs，所以只能用动态布尔值控制关闭
         toggle : false,
         toggle2 : false,
+        toggle3 : false,
         actions2: [
             {
                 name: '删除',
@@ -64,5 +65,10 @@ Page({
         this.setData({
             visible2: true
         });
+    },
+    toggleButton() { // 因为是watch toggle3 的变化，所以点击其他地方隐藏右侧的button时需要点击两次才能拉出来
+        this.setData({
+            toggle3: !this.data.toggle3
+        })
     }
 });

--- a/examples/pages/swipeout/index.wxml
+++ b/examples/pages/swipeout/index.wxml
@@ -101,4 +101,17 @@
            </view>
         </view>
     </i-swipeout>
+
+    <view class="i-swipeout-demo-title">点击删除按钮toggle</view>
+    <i-swipeout  i-class="i-swipeout-demo-item" actions="{{actions}}" toggle="{{toggle3}}">
+        <view slot="content">
+           <view class="i-swipeout-image" style="background:#ed3f14;" bindtap="toggleButton" >
+                <i-icon size="20" color="#FFFFFF" type="delete_fill" />
+           </view>
+           <view class="i-swipeout-des">
+                <view class="i-swipeout-des-h2">第七个小矮人</view>
+                <view class="i-swipeout-des-detail">乐观善良的7个小矮人原本过着简单快乐的生活，不料诅咒公主的巫婆利用小矮人进入.</view>
+           </view>
+        </view>
+    </i-swipeout>
 </view>

--- a/src/swipeout/index.js
+++ b/src/swipeout/index.js
@@ -22,7 +22,7 @@ Component({
         toggle : {
             value : false,
             type : Boolean,
-            observer : 'closeButtonGroup'
+            observer : 'toggleButtonGroup'
         },
         operateWidth : {
             type : Number,
@@ -153,6 +153,12 @@ Component({
             if( !this.data.unclosable ){
                 this.closeButtonGroup();
             }
+        },
+        toggleButtonGroup(event) {
+            let pageX = this.data.toggle ? - this.data.limitMove : 0
+            this.setData({
+                'position': {pageX, pageY: 0}
+            })
         }
     },
     ready(){


### PR DESCRIPTION
目前的swipeout 组件好像只能通过手势滑动才能拉出右侧的buttons，作者原来也有设置一个toggle属性。
把toggle属性的`observer`修改为`toggleButtonGroup`，通过点击按钮来设置toggle的值达到toggle的目的。