### PR TITLE
修复索引器右侧字母索引与左侧内容差一位问题

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -117,7 +117,7 @@ Component({
             const touches = event.touches[0] || {};
             const pageY = touches.pageY;
             const rest = pageY - data.startTop;
-            let index = Math.ceil( rest/data.itemHeight );
+            let index = Math.floor( rest/data.itemHeight );
             index = index >= data.itemLength ? data.itemLength -1 : index;
             const movePosition = this.getCurrentItem(index);
 

--- a/src/index/index.js
+++ b/src/index/index.js
@@ -117,7 +117,7 @@ Component({
             const touches = event.touches[0] || {};
             const pageY = touches.pageY;
             const rest = pageY - data.startTop;
-            let index = Math.ceil( rest/data.itemHeight );
+            let index = Math.floor( rest/data.itemHeight );
             index = index >= data.itemLength ? data.itemLength -1 : index;
             const movePosition = this.getCurrentItem(index);
 


### PR DESCRIPTION
计算距离是向下取整，开发者工具切换模拟器测试正常，iphone8真机,华为mate7正常