### PR TITLE
解决index索引组件存在的2个bug(1.索引首位字母定位不准确2.滑动超出边界报错)

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -99,26 +99,16 @@ Component({
         triggerCallback(options){
             this.triggerEvent('change',options)
         },
-        handlerFixedTap(event){
-            const eindex = event.currentTarget.dataset.index;
-            const item = this.getCurrentItem(eindex);
-            this.setData({
-                scrollTop : item.top,
-                currentName : item.currentName,
-                isTouches : true
-            })
-            this.triggerCallback({
-                index : eindex,
-                current : item.currentName
-            })
-        },
         handlerTouchMove(event){
             const data = this.data;
             const touches = event.touches[0] || {};
             const pageY = touches.pageY;
             const rest = pageY - data.startTop;
-            let index = Math.ceil( rest/data.itemHeight );
+            let index = Math.floor( rest/data.itemHeight );
             index = index >= data.itemLength ? data.itemLength -1 : index;
+            if(index<0){
+                return ;
+            }
             const movePosition = this.getCurrentItem(index);
 
            /*

--- a/dist/index/index.wxml
+++ b/dist/index/index.wxml
@@ -13,7 +13,7 @@
                 wx:for="{{fixedData}}" 
                 wx:key="{{index}}" 
                 data-index="{{index}}" 
-                catchtap="handlerFixedTap">
+                >
                 {{item}}
             </view>
         </view>  

--- a/src/index/index.js
+++ b/src/index/index.js
@@ -99,26 +99,16 @@ Component({
         triggerCallback(options){
             this.triggerEvent('change',options)
         },
-        handlerFixedTap(event){
-            const eindex = event.currentTarget.dataset.index;
-            const item = this.getCurrentItem(eindex);
-            this.setData({
-                scrollTop : item.top,
-                currentName : item.currentName,
-                isTouches : true
-            })
-            this.triggerCallback({
-                index : eindex,
-                current : item.currentName
-            })
-        },
         handlerTouchMove(event){
             const data = this.data;
             const touches = event.touches[0] || {};
             const pageY = touches.pageY;
             const rest = pageY - data.startTop;
-            let index = Math.ceil( rest/data.itemHeight );
+            let index = Math.floor( rest/data.itemHeight );
             index = index >= data.itemLength ? data.itemLength -1 : index;
+            if(index<0){
+                return ;
+            }
             const movePosition = this.getCurrentItem(index);
 
            /*

--- a/src/index/index.wxml
+++ b/src/index/index.wxml
@@ -13,7 +13,7 @@
                 wx:for="{{fixedData}}" 
                 wx:key="{{index}}" 
                 data-index="{{index}}" 
-                catchtap="handlerFixedTap">
+                >
                 {{item}}
             </view>
         </view>  


### PR DESCRIPTION
解决index索引组件存在的2个bug，以及删除一个多余tap事件：1.点击索引首位字母定位不准确2.滑动超出边界时报错3.删除索引的tap事件，因为catchtouchstart,catchtouchend后事件被阻止了，tap捕获不到，用已有的catchtouchstart代替索引点击就行