### PR TITLE
解决开发者工具中input不设置maxlength就无法输入值的问题

### DIFF
--- a/src/input/index.js
+++ b/src/input/index.js
@@ -37,7 +37,8 @@ Component({
             value: false
         },
         maxlength: {
-            type: Number
+            type: Number,
+            value: 25
         }
     },
 


### PR DESCRIPTION
给input组件的maxlength属性设置一个合适的默认值，让开发者在缺省i-input标签的maxlength属性时在微信开发者工具中可以正常输入