### PR TITLE
notice-bar adds close event listener

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -117,8 +117,8 @@ Component({
             const touches = event.touches[0] || {};
             const pageY = touches.pageY;
             const rest = pageY - data.startTop;
-            let index = Math.ceil( rest/data.itemHeight );
-            index = index >= data.itemLength ? data.itemLength -1 : index;
+            let index = Math.floor( rest/data.itemHeight );
+            index = index >= data.itemLength ? data.itemLength -1 : ( index <= 0 ? 0 : index );
             const movePosition = this.getCurrentItem(index);
 
            /*

--- a/dist/notice-bar/index.js
+++ b/dist/notice-bar/index.js
@@ -101,12 +101,13 @@ Component({
                 clearTimeout(this.data.timer);
             }
         },
-        handleClose() {
+        handleClose(e) {
             this.destroyTimer();
             this.setData({
                 show: false,
                 timer: null
             });
+            this.triggerEvent('close', e);
         }
     }
 });

--- a/src/notice-bar/index.js
+++ b/src/notice-bar/index.js
@@ -101,12 +101,13 @@ Component({
                 clearTimeout(this.data.timer);
             }
         },
-        handleClose() {
+        handleClose(e) {
             this.destroyTimer();
             this.setData({
                 show: false,
                 timer: null
             });
+            this.triggerEvent('close', e);
         }
     }
 });


### PR DESCRIPTION
1. 为`notice-bar`添加了`close`监听事件，引用页面可以用以下方式监听关闭事件。（第三方数据监测有此需求。）
```
<notice-bar bind:close="页面内自定义监听事件"></notice-bar>
```

2. `index.js`的修改是由于 [d3772ea](https://github.com/TalkingData/iview-weapp/commit/d3772ea81c21c21f5c63bc11ece029d95688e846) 这次提交未执行`npm run prod`更新`dist`。